### PR TITLE
[eroprofile] use _parse_html5_media_entries

### DIFF
--- a/youtube_dl/extractor/eroprofile.py
+++ b/youtube_dl/extractor/eroprofile.py
@@ -77,20 +77,21 @@ class EroProfileIE(InfoExtractor):
             [r"glbUpdViews\s*\('\d*','(\d+)'", r'p/report/video/(\d+)'],
             webpage, 'video id', default=None)
 
-        video_url = unescapeHTML(self._search_regex(
-            r'<source src="([^"]+)', webpage, 'video url'))
+        info = self._parse_html5_media_entries(url, webpage, video_id)[0]
+
         title = self._html_search_regex(
             [r'<h1[^>]*>([^<]+)</h1>', r'Title:</th><td>([^<]+)</td>'],
             webpage, 'title')
+
+        info.update({
+            'id': video_id,
+            'title': title,
+            'age_limit': 18,
+        })
+
         thumbnail = self._html_search_regex(
             [r'<div class="playlistItem current">.*?<img src="([^"]+)"', r'onclick="showVideoPlayer\(\)"><img src="([^"]+)'],
             webpage, 'thumbnail', fatal=False)
+        info.setdefault('thumbnail', thumbnail)
 
-        return {
-            'id': video_id,
-            'display_id': display_id,
-            'url': video_url,
-            'title': title,
-            'thumbnail': thumbnail,
-            'age_limit': 18,
-        }
+        return info

--- a/youtube_dl/extractor/eroprofile.py
+++ b/youtube_dl/extractor/eroprofile.py
@@ -4,10 +4,7 @@ import re
 
 from .common import InfoExtractor
 from ..compat import compat_urllib_parse_urlencode
-from ..utils import (
-    ExtractorError,
-    unescapeHTML
-)
+from ..utils import ExtractorError
 
 
 class EroProfileIE(InfoExtractor):


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Use `_parse_html5_media_entries` for the video and thumbnail URLs. (For the thumbnail we also keep the old regexes as a fallback.)

Requested in #23626.